### PR TITLE
Adds a shadow node implementation for sliders & autolinking

### DIFF
--- a/example/android/app/src/main/java/com/example/newarchitecture/components/MainComponentsRegistry.java
+++ b/example/android/app/src/main/java/com/example/newarchitecture/components/MainComponentsRegistry.java
@@ -15,10 +15,6 @@ import com.facebook.soloader.SoLoader;
  */
 @DoNotStrip
 public class MainComponentsRegistry {
-  static {
-    SoLoader.loadLibrary("fabricjni");
-  }
-
   @DoNotStrip private final HybridData mHybridData;
 
   @DoNotStrip

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -60,11 +60,3 @@ dependencies {
   //noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
 }
-
-if (isNewArchitectureEnabled()) {
-    react {
-        jsRootDir = file("../src")
-        libraryName = "ReactSlider"
-        codegenJavaPackageName = "com.reactnativecommunity.slider"
-    }
-}

--- a/package/android/src/main/jni/CMakeLists.txt
+++ b/package/android/src/main/jni/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+set(LIB_LITERAL rncslider)
+set(LIB_TARGET_NAME react_codegen_${LIB_LITERAL})
+
+set(LIB_ANDROID_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+set(LIB_COMMON_DIR ${LIB_ANDROID_DIR}/../common/cpp)
+set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/build/generated/source/codegen/jni)
+set(LIB_ANDROID_GENERATED_COMPONENTS_DIR ${LIB_ANDROID_GENERATED_JNI_DIR}/react/renderer/components/${LIB_LITERAL})
+
+add_compile_options(
+  -fexceptions
+  -frtti
+  -std=c++17
+  -Wall
+  -Wpedantic
+  -Wno-gnu-zero-variadic-macro-arguments
+)
+
+file(GLOB LIB_CUSTOM_SRCS CONFIGURE_DEPENDS *.cpp ${LIB_COMMON_DIR}/react/renderer/components/${LIB_LITERAL}/*.cpp)
+file(GLOB LIB_CODEGEN_SRCS CONFIGURE_DEPENDS ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}/*.cpp)
+
+add_library(
+  ${LIB_TARGET_NAME}
+  SHARED 
+  ${LIB_CUSTOM_SRCS}
+  ${LIB_CODEGEN_SRCS}
+)
+
+target_include_directories(
+  ${LIB_TARGET_NAME}
+  PUBLIC 
+  . 
+  ${LIB_COMMON_DIR}
+  ${LIB_ANDROID_GENERATED_JNI_DIR}
+  ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
+)
+
+target_link_libraries(
+  ${LIB_TARGET_NAME}
+  fbjni
+  folly_runtime
+  glog
+  jsi
+  react_codegen_rncore
+  react_debug
+  react_nativemodule_core
+  react_render_componentregistry
+  react_render_core
+  react_render_debug
+  react_render_graphics
+  react_render_imagemanager
+  react_render_mapbuffer
+  rrc_image
+  rrc_view
+  turbomodulejsijni
+  yoga
+)
+
+target_compile_options(
+  ${LIB_TARGET_NAME}
+  PRIVATE
+  -DLOG_TAG=\"ReactNative\"
+  -fexceptions
+  -frtti
+  -std=c++17
+  -Wall
+)
+
+target_include_directories(
+ ${CMAKE_PROJECT_NAME}
+ PUBLIC
+ ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/package/android/src/main/jni/rncslider.cpp
+++ b/package/android/src/main/jni/rncslider.cpp
@@ -1,0 +1,11 @@
+#include "rncslider.h"
+
+namespace facebook::react
+{
+
+    std::shared_ptr<TurboModule> rncslider_ModuleProvider(const std::string &moduleName, const JavaTurboModule::InitParams &params)
+    {
+        return nullptr;
+    }
+
+} // namespace facebook::react

--- a/package/android/src/main/jni/rncslider.h
+++ b/package/android/src/main/jni/rncslider.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ReactCommon/JavaTurboModule.h>
+#include <ReactCommon/TurboModule.h>
+#include <jsi/jsi.h>
+#include <react/renderer/components/rncslider/RNCSliderComponentDescriptor.h>
+
+namespace facebook::react
+{
+    JSI_EXPORT
+    std::shared_ptr<TurboModule> rncslider_ModuleProvider(const std::string &moduleName, const JavaTurboModule::InitParams &params);
+
+} // namespace facebook::react

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -1,11 +1,14 @@
 package com.reactnativecommunity.slider;
 
+import android.content.Context;
+import android.view.View;
 import android.widget.SeekBar;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -17,6 +20,11 @@ import java.util.Map;
 import com.facebook.react.viewmanagers.RNCSliderManagerInterface;
 import com.facebook.react.viewmanagers.RNCSliderManagerDelegate;
 import com.facebook.react.module.annotations.ReactModule;
+
+import com.facebook.yoga.YogaMeasureFunction;
+import com.facebook.yoga.YogaMeasureMode;
+import com.facebook.yoga.YogaMeasureOutput;
+import com.facebook.yoga.YogaNode;
 
 /**
  * Manages instances of {@code ReactSlider}.
@@ -210,4 +218,23 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
 
   @Override
   public void setVertical(ReactSlider view, boolean value) {}
+
+  @Override
+  public long measure(
+      Context context,
+      ReadableMap localData,
+      ReadableMap props,
+      ReadableMap state,
+      float width,
+      YogaMeasureMode widthMode,
+      float height,
+      YogaMeasureMode heightMode,
+      @Nullable float[] attachmentsPositions) {
+        SeekBar reactSlider = new ReactSlider(context, null);
+        final int spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+        reactSlider.measure(spec, spec);
+        return YogaMeasureOutput.make(
+          PixelUtil.toDIPFromPixel(reactSlider.getMeasuredWidth()),
+          PixelUtil.toDIPFromPixel(reactSlider.getMeasuredHeight()));
+  }
 }

--- a/package/common/cpp/react/renderer/components/rncslider/RNCSliderComponentDescriptor.h
+++ b/package/common/cpp/react/renderer/components/rncslider/RNCSliderComponentDescriptor.h
@@ -1,0 +1,46 @@
+
+#pragma once
+
+#include "RNCSliderMeasurementsManager.h"
+#include "RNCSliderShadowNode.h"
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react
+{
+
+    /*
+     * Descriptor for <RNCSlider> component.
+     */
+    class RNCSliderComponentDescriptor final
+        : public ConcreteComponentDescriptor<RNCSliderShadowNode>
+    {
+    public:
+        RNCSliderComponentDescriptor(
+            const ComponentDescriptorParameters &parameters)
+            : ConcreteComponentDescriptor(parameters),
+              measurementsManager_(std::make_shared<RNCSliderMeasurementsManager>(
+                  contextContainer_)) {}
+
+        void adopt(ShadowNode::Unshared const &shadowNode) const override
+        {
+            ConcreteComponentDescriptor::adopt(shadowNode);
+
+            auto sliderShadowNode =
+                std::static_pointer_cast<RNCSliderShadowNode>(shadowNode);
+
+            // `RNCSliderShadowNode` uses `RNCSliderMeasurementsManager` to
+            // provide measurements to Yoga.
+            sliderShadowNode->setRNCSliderMeasurementsManager(
+                measurementsManager_);
+
+            // All `RNCSliderShadowNode`s must have leaf Yoga nodes with properly
+            // setup measure function.
+            sliderShadowNode->enableMeasurement();
+        }
+
+    private:
+        const std::shared_ptr<RNCSliderMeasurementsManager> measurementsManager_;
+    };
+
+} // namespace facebook::react

--- a/package/common/cpp/react/renderer/components/rncslider/RNCSliderMeasurementsManager.cpp
+++ b/package/common/cpp/react/renderer/components/rncslider/RNCSliderMeasurementsManager.cpp
@@ -1,0 +1,62 @@
+#include "RNCSliderMeasurementsManager.h"
+
+#include <fbjni/fbjni.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <react/renderer/core/conversions.h>
+
+using namespace facebook::jni;
+
+namespace facebook::react
+{
+
+    Size RNCSliderMeasurementsManager::measure(
+        SurfaceId surfaceId,
+        LayoutConstraints layoutConstraints) const
+    {
+        {
+            std::scoped_lock lock(mutex_);
+            if (hasBeenMeasured_)
+            {
+                return cachedMeasurement_;
+            }
+        }
+
+        const jni::global_ref<jobject> &fabricUIManager =
+            contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
+
+        static auto measure =
+            jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
+                ->getMethod<jlong(
+                    jint,
+                    jstring,
+                    ReadableMap::javaobject,
+                    ReadableMap::javaobject,
+                    ReadableMap::javaobject,
+                    jfloat,
+                    jfloat,
+                    jfloat,
+                    jfloat)>("measure");
+
+        auto minimumSize = layoutConstraints.minimumSize;
+        auto maximumSize = layoutConstraints.maximumSize;
+
+        local_ref<JString> componentName = make_jstring("RNCSlider");
+
+        auto measurement = yogaMeassureToSize(measure(
+            fabricUIManager,
+            surfaceId,
+            componentName.get(),
+            nullptr,
+            nullptr,
+            nullptr,
+            minimumSize.width,
+            maximumSize.width,
+            minimumSize.height,
+            maximumSize.height));
+
+        std::scoped_lock lock(mutex_);
+        cachedMeasurement_ = measurement;
+        return measurement;
+    }
+
+} // namespace facebook::react

--- a/package/common/cpp/react/renderer/components/rncslider/RNCSliderMeasurementsManager.h
+++ b/package/common/cpp/react/renderer/components/rncslider/RNCSliderMeasurementsManager.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/utils/ContextContainer.h>
+
+namespace facebook::react
+{
+
+    class RNCSliderMeasurementsManager
+    {
+    public:
+        RNCSliderMeasurementsManager(
+            const ContextContainer::Shared &contextContainer)
+            : contextContainer_(contextContainer) {}
+
+        Size measure(SurfaceId surfaceId, LayoutConstraints layoutConstraints) const;
+
+    private:
+        const ContextContainer::Shared contextContainer_;
+        mutable std::mutex mutex_;
+        mutable bool hasBeenMeasured_ = false;
+        mutable Size cachedMeasurement_{};
+    };
+
+} // namespace facebook::react

--- a/package/common/cpp/react/renderer/components/rncslider/RNCSliderShadowNode.cpp
+++ b/package/common/cpp/react/renderer/components/rncslider/RNCSliderShadowNode.cpp
@@ -1,0 +1,25 @@
+#include "RNCSliderShadowNode.h"
+
+namespace facebook::react
+{
+
+    extern const char RNCSliderComponentName[] = "RNCSlider";
+
+    void RNCSliderShadowNode::setRNCSliderMeasurementsManager(
+        const std::shared_ptr<RNCSliderMeasurementsManager> &
+            measurementsManager)
+    {
+        ensureUnsealed();
+        measurementsManager_ = measurementsManager;
+    }
+
+#pragma mark - LayoutableShadowNode
+
+    Size RNCSliderShadowNode::measureContent(
+        const LayoutContext & /*layoutContext*/,
+        const LayoutConstraints &layoutConstraints) const
+    {
+        return measurementsManager_->measure(getSurfaceId(), layoutConstraints);
+    }
+
+} // namespace facebook::react

--- a/package/common/cpp/react/renderer/components/rncslider/RNCSliderShadowNode.h
+++ b/package/common/cpp/react/renderer/components/rncslider/RNCSliderShadowNode.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "RNCSliderMeasurementsManager.h"
+
+#include <react/renderer/components/rncslider/EventEmitters.h>
+#include <react/renderer/components/rncslider/Props.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react
+{
+
+    JSI_EXPORT extern const char RNCSliderComponentName[];
+
+    /*
+     * `ShadowNode` for <RNCSlider> component.
+     */
+    class JSI_EXPORT RNCSliderShadowNode final : public ConcreteViewShadowNode<
+                                                     RNCSliderComponentName,
+                                                     RNCSliderProps,
+                                                     RNCSliderEventEmitter>
+    {
+    public:
+        using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+        // Associates a shared `RNCSliderMeasurementsManager` with the node.
+        void setRNCSliderMeasurementsManager(
+            const std::shared_ptr<RNCSliderMeasurementsManager> &
+                measurementsManager);
+
+#pragma mark - LayoutableShadowNode
+
+        Size measureContent(
+            const LayoutContext &layoutContext,
+            const LayoutConstraints &layoutConstraints) const override;
+
+    private:
+        std::shared_ptr<RNCSliderMeasurementsManager> measurementsManager_;
+    };
+
+} // namespace facebook::react

--- a/package/package.json
+++ b/package/package.json
@@ -64,12 +64,11 @@
     "jsxBracketSameLine": true
   },
   "codegenConfig": {
-    "libraries": [
-      {
-        "name": "RNCSlider",
-        "type": "components",
-        "jsSrcsDir": "src"
-      }
-    ]
+    "name": "rncslider",
+    "type": "components",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackage": "com.reactnativecommunity.slider"
+    }
   }
 }

--- a/package/react-native.config.js
+++ b/package/react-native.config.js
@@ -1,0 +1,22 @@
+let supportsCodegenConfig = false;
+try {
+  const rnCliAndroidVersion =
+    require('@react-native-community/cli-platform-android/package.json').version;
+  const [major] = rnCliAndroidVersion.split('.');
+  supportsCodegenConfig = major >= 9;
+} catch (e) {
+  // ignore
+}
+
+module.exports = {
+  dependency: {
+    platforms: {
+      android: supportsCodegenConfig ? {
+        componentDescriptors: [
+          "RNCSliderComponentDescriptor"
+        ],
+        cmakeListsPath: "../android/src/main/jni/CMakeLists.txt"
+      } : {},
+    },
+  },
+}

--- a/package/src/RNCSliderNativeComponent.ts
+++ b/package/src/RNCSliderNativeComponent.ts
@@ -41,6 +41,6 @@ export interface NativeProps extends ViewProps {
   upperLimit?: Float;
 }
 
-export default codegenNativeComponent<NativeProps>(
-  'RNCSlider',
-) as HostComponent<NativeProps>;
+export default codegenNativeComponent<NativeProps>('RNCSlider', {
+  interfaceOnly: true,
+}) as HostComponent<NativeProps>;


### PR DESCRIPTION
# What's broken? 
When we enable fabric all of our sliders have zero height and aren't interactable as a result. This works in old arch because there's a [custom shadow node implementation in java](https://github.com/discord/react-native-slider/blob/c033553a67224129ec4ba1aa004191afcf6504c5/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java#L81) that allocates a slider, measures it, and provides the measurements.

# How'd we fix it?
Inspired by the [switch shadow node implementation](https://github.com/facebook/react-native/blob/118e651bc28d089f72e2ea3696ca711f21d7ada6/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.cpp#L4) in react native core we added a cpp shadow node to measure the slider to duplicate what was previously happening with the old architecture

# How do I test this? (in discord)
* Build with new arch enabled
* Go to voice setting under profile
* Try to slide the volume sliders