### PR TITLE
Fixes slider thumb jumping while panning in new arch

### DIFF
--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -95,33 +95,45 @@ public class ReactSlider extends AppCompatSeekBar {
   }
 
   /* package */ void setMaxValue(double max) {
-    mMaxValue = max;
-    updateAll();
+      if (max != mMaxValue) {
+        mMaxValue = max;
+        updateAll();
+      }
   }
 
   /* package */ void setMinValue(double min) {
-    mMinValue = min;
-    updateAll();
+      if (min != mMinValue) {
+        mMinValue = min;
+        updateAll();
+      }
   }
 
   /* package */ void setValue(double value) {
-    mValue = value;
-    updateValue();
+      if (value != mValue) {
+        mValue = value;
+        updateValue();
+      }
   }
 
   /* package */ void setStep(double step) {
-    mStep = step;
-    updateAll();
+      if (step != mStep) {
+        mStep = step;
+        updateAll();
+      }
   }
 
   /* package */ void setLowerLimit(double value) {
-    mRealLowerLimit = value;
-    updateLowerLimit();
+      if (value != mRealLowerLimit) {
+        mRealLowerLimit = value;
+        updateLowerLimit();
+      }
   }
 
   /* package */ void setUpperLimit(double value) {
-    mRealUpperLimit = value;
-    updateUpperLimit();
+      if (value != mRealUpperLimit) {
+        mRealUpperLimit = value;
+        updateUpperLimit();
+      }
   }
 
   int getLowerLimit() {

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -54,6 +54,7 @@ public class ReactSlider extends AppCompatSeekBar {
    * component).
    */
   private double mValue = 0;
+  private boolean mHasSetValue = false;
 
   private boolean isSliding = false;
 
@@ -109,8 +110,9 @@ public class ReactSlider extends AppCompatSeekBar {
   }
 
   /* package */ void setValue(double value) {
-      if (value != mValue) {
+      if (value != mValue && !mHasSetValue) {
         mValue = value;
+        mHasSetValue = true;
         updateValue();
       }
   }

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -110,7 +110,7 @@ public class ReactSlider extends AppCompatSeekBar {
   }
 
   /* package */ void setValue(double value) {
-      if (value != mValue && !mHasSetValue) {
+      if (!mHasSetValue) {
         mValue = value;
         mHasSetValue = true;
         updateValue();


### PR DESCRIPTION
# What's broken? 
When panning sliders with new arch enabled, we visually can see the slider thumb jumping in the middle of trying to pan the slider.

# How'd we fix it?

This code is causing a feedback loop that's specific to the fabric renderer.
1. You start panning the slider thumb
2. The native component emits a value change in js land
3. We update some store
4. The component re-renders with new props
5. The native implementation's view manager receives new props
6. New props are set here on the actual view

The view manager guards against this use case partially in its [setValue implementation](https://github.com/discord/react-native-slider/blob/c033553a67224129ec4ba1aa004191afcf6504c5/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java#L39) to avoid values coming in from updating the view's value while you're actively interacting with it. With fabric though we're getting values in for every prop on every state update even if they're unchanged which calls `updateAll` 3 times per state update.

There was also some jank where the slider would get stuck in a re-render loop at the end of dragging. The doc comments mention that this isn't a controlled component, but when sliding ends it starts taking in updates to value. This also adds `mHasSetValue` to make sure value updates are ignored past the first value.

# How do I test this? (in discord)
* Build with new arch enabled
* Go to voice setting under profile
* Try to slide the volume sliders